### PR TITLE
fix(book2): restore pages to canonical path

### DIFF
--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page01.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page01.md
@@ -1,0 +1,9 @@
+# Page 01
+
+Cover image
+
+// Code Task: cover_image() → RESULT: "Stub."
+[python]
+def cover_image():
+    return "Stub."
+[Illustration: (placeholder)]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page02.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page02.md
@@ -1,0 +1,9 @@
+# Page 02
+
+Title page
+
+// Code Task: title_page() → RESULT: "Stub."
+[python]
+def title_page():
+    return "Stub."
+[Illustration: (placeholder)]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page03.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page03.md
@@ -1,0 +1,11 @@
+# Page 03
+
+
+Welcome, riddle-fixer! Here, every puzzle can be mended with a kind heart.
+Will you help us find gentle ways to repair what feels tricky?
+
+// Code Task: dedication_hook() → RESULT: "Stub."
+[python]
+def dedication_hook():
+    return "Stub."
+[Illustration: An open book with glowing chalk glyphs and a gentle key, inviting the reader in.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page03.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page03.md
@@ -1,6 +1,5 @@
 # Page 03
 
-
 Welcome, riddle-fixer! Here, every puzzle can be mended with a kind heart.
 Will you help us find gentle ways to repair what feels tricky?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page04.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page04.md
@@ -1,0 +1,11 @@
+# Page 04
+
+
+In the village square, friends gather to share riddles and laughter.
+Chalk glyphs and question-flowers bloom as everyone joins in the fun.
+
+// Code Task: village_loves_riddles() → RESULT: "Stub."
+[python]
+def village_loves_riddles():
+    return "Stub."
+[Illustration: Children and grown-ups laughing together, question-flowers and chalk drawings all around.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page04.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page04.md
@@ -1,6 +1,5 @@
 # Page 04
 
-
 In the village square, friends gather to share riddles and laughter.
 Chalk glyphs and question-flowers bloom as everyone joins in the fun.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page05.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page05.md
@@ -1,6 +1,5 @@
 # Page 05
 
-
 One riddle feels sharp, leaving a knot in someone’s chest.
 Can you notice when a puzzle stops feeling kind?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page05.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page05.md
@@ -1,0 +1,11 @@
+# Page 05
+
+
+One riddle feels sharp, leaving a knot in someone’s chest.
+Can you notice when a puzzle stops feeling kind?
+
+// Code Task: riddles_sting() → RESULT: "Stub."
+[python]
+def riddles_sting():
+    return "Stub."
+[Illustration: A child pausing, a faint knot in the air, others noticing with gentle concern.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page06.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page06.md
@@ -1,0 +1,11 @@
+# Page 06
+
+
+A child sits quietly, unsure how to untangle the tricky riddle.
+Would you like to help her find a gentle clue?
+
+// Code Task: child_stumped() → RESULT: "Stub."
+[python]
+def child_stumped():
+    return "Stub."
+[Illustration: The child looking thoughtful, a soft key and a question-flower nearby, warm twilight colors.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page06.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page06.md
@@ -1,6 +1,5 @@
 # Page 06
 
-
 A child sits quietly, unsure how to untangle the tricky riddle.
 Would you like to help her find a gentle clue?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page07.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page07.md
@@ -1,6 +1,5 @@
 # Page 07
 
-
 At the edge of the woods, a warm lantern glows beneath the twilight trees.
 Shall we follow the winding path to see who lights the way?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page07.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page07.md
@@ -1,0 +1,11 @@
+# Page 07
+
+
+At the edge of the woods, a warm lantern glows beneath the twilight trees.
+Shall we follow the winding path to see who lights the way?
+
+// Code Task: lantern_in_wood() → RESULT: "Stub."
+[python]
+def lantern_in_wood():
+    return "Stub."
+[Illustration: A lantern glowing on a tree branch, a winding path through gentle woods, hints of chalk marks.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page08.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page08.md
@@ -1,6 +1,5 @@
 # Page 08
 
-
 The Witch Who Broke Riddles smiles, her cloak covered in tiny keys and soft knots.
 She welcomes all with a gentle voice: “Here, every question is safe.”
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page08.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page08.md
@@ -1,0 +1,11 @@
+# Page 08
+
+
+The Witch Who Broke Riddles smiles, her cloak covered in tiny keys and soft knots.
+She welcomes all with a gentle voice: “Here, every question is safe.”
+
+// Code Task: meet_witch() → RESULT: "Stub."
+[python]
+def meet_witch():
+    return "Stub."
+[Illustration: The witch in a patchwork cloak, keys and knots visible, smiling kindly in the lantern’s glow.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page09.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page09.md
@@ -1,0 +1,11 @@
+# Page 09
+
+
+The witch listens closely as the child shares her riddle, nodding with care.
+What do you notice about how she listens?
+
+// Code Task: witch_hears_riddle() → RESULT: "Stub."
+[python]
+def witch_hears_riddle():
+    return "Stub."
+[Illustration: The witch and child sitting together, the witch listening, question-flowers floating nearby.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page09.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page09.md
@@ -1,6 +1,5 @@
 # Page 09
 
-
 The witch listens closely as the child shares her riddle, nodding with care.
 What do you notice about how she listens?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page10.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page10.md
@@ -1,6 +1,5 @@
 # Page 10
 
-
 With a gentle touch, the witch unclicks a tangled thread—no scolding, just kindness.
 Can you imagine a new rule that feels softer for everyone?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page10.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page10.md
@@ -1,0 +1,11 @@
+# Page 10
+
+
+With a gentle touch, the witch unclicks a tangled thread—no scolding, just kindness.
+Can you imagine a new rule that feels softer for everyone?
+
+// Code Task: snap_mean_rule() → RESULT: "Stub."
+[python]
+def snap_mean_rule():
+    return "Stub."
+[Illustration: A thread gently unclicking, the witch’s hands soft, warm twilight colors, no harsh lines.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page11.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page11.md
@@ -1,0 +1,11 @@
+# Page 11
+
+
+Neighbors gather in a bright hush, eyebrows shaped like question marks.
+What’s the kindest question you want to ask first?
+
+// Code Task: crowd_gathers() → RESULT: "Stub."
+[python]
+def crowd_gathers():
+    return "Stub."
+[Illustration: Lantern-lit square; diverse villagers leaning in; soft glow on faces.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page11.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page11.md
@@ -1,6 +1,5 @@
 # Page 11
 
-
 Neighbors gather in a bright hush, eyebrows shaped like question marks.
 What’s the kindest question you want to ask first?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page12.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page12.md
@@ -1,6 +1,5 @@
 # Page 12
 
-
 A fresh riddle flutters like leaves—every answer seems to fit.
 Which clues help most, and which feel too wiggly?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page12.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page12.md
@@ -1,0 +1,11 @@
+# Page 12
+
+
+A fresh riddle flutters like leaves—every answer seems to fit.
+Which clues help most, and which feel too wiggly?
+
+// Code Task: new_riddle_many_answers() → RESULT: "Stub."
+[python]
+def new_riddle_many_answers():
+    return "Stub."
+[Illustration: Swirling paper leaves with faint symbols; options floating; curious smiles.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page13.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page13.md
@@ -1,0 +1,11 @@
+# Page 13
+
+
+The witch ties a gentle knot: “Let’s choose one fair rule.”
+Pick a rule that guides, not traps—what would you choose?
+
+// Code Task: tie_guiding_knot() → RESULT: "Stub."
+[python]
+def tie_guiding_knot():
+    return "Stub."
+[Illustration: Ribbon-knot glowing; one strand labeled “kind rule”.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page13.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page13.md
@@ -1,6 +1,5 @@
 # Page 13
 
-
 The witch ties a gentle knot: “Let’s choose one fair rule.”
 Pick a rule that guides, not traps—what would you choose?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page14.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page14.md
@@ -1,6 +1,5 @@
 # Page 14
 
-
 The riddle turns like a lantern arrow, pointing softly.
 Follow the glow—where does it guide you first?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page14.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page14.md
@@ -1,0 +1,11 @@
+# Page 14
+
+
+The riddle turns like a lantern arrow, pointing softly.
+Follow the glow—where does it guide you first?
+
+// Code Task: riddle_points_kindly() → RESULT: "Stub."
+[python]
+def riddle_points_kindly():
+    return "Stub."
+[Illustration: Arrow-light across cobblestones; question-flowers edging the path.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page15.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page15.md
@@ -1,0 +1,11 @@
+# Page 15
+
+
+Hands lift; guesses braid like rope across a little gap.
+Offer a clue that helps someone else cross.
+
+// Code Task: village_tries_together() → RESULT: "Stub."
+[python]
+def village_tries_together():
+    return "Stub."
+[Illustration: Children and elders sharing; a rope-bridge of words.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page15.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page15.md
@@ -1,6 +1,5 @@
 # Page 15
 
-
 Hands lift; guesses braid like rope across a little gap.
 Offer a clue that helps someone else cross.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page16.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page16.md
@@ -1,0 +1,11 @@
+# Page 16
+
+
+A loud riddler struts in, puffed up like a rooster.
+Welcome him kindly—what rule keeps our game fair?
+
+// Code Task: boastful_riddler_arrives() → RESULT: "Stub."
+[python]
+def boastful_riddler_arrives():
+    return "Stub."
+[Illustration: Jaunty hat; chalkboard behind him; friendly faces nearby.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page16.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page16.md
@@ -1,6 +1,5 @@
 # Page 16
 
-
 A loud riddler struts in, puffed up like a rooster.
 Welcome him kindly—what rule keeps our game fair?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page17.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page17.md
@@ -1,0 +1,11 @@
+# Page 17
+
+
+His riddle snaps shut like a box with no door.
+Spot the trick—what part feels unkind?
+
+// Code Task: trap_riddle() → RESULT: "Stub."
+[python]
+def trap_riddle():
+    return "Stub."
+[Illustration: Little box with spiky chalk glyphs; tiny padlock drawn on.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page17.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page17.md
@@ -1,6 +1,5 @@
 # Page 17
 
-
 His riddle snaps shut like a box with no door.
 Spot the trick—what part feels unkind?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page18.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page18.md
@@ -1,6 +1,5 @@
 # Page 18
 
-
 The box clicks tighter when answers are honest.
 Where could a gentler hinge go? Point to it.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page18.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page18.md
@@ -1,0 +1,11 @@
+# Page 18
+
+
+The box clicks tighter when answers are honest.
+Where could a gentler hinge go? Point to it.
+
+// Code Task: flip_trap_to_bridge() → RESULT: "Stub."
+[python]
+def flip_trap_to_bridge():
+    return "Stub."
+[Illustration: Same box; sketched hinge ghosted on one edge; witch tapping the spot.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page19.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page19.md
@@ -1,6 +1,5 @@
 # Page 19
 
-
 The riddler’s cheeks warm like sunrise; he nods to the kinder rule.
 Tell him one thing you enjoyed about his puzzle.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page19.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page19.md
@@ -1,0 +1,11 @@
+# Page 19
+
+
+The riddler’s cheeks warm like sunrise; he nods to the kinder rule.
+Tell him one thing you enjoyed about his puzzle.
+
+// Code Task: riddler_learns() → RESULT: "Stub."
+[python]
+def riddler_learns():
+    return "Stub."
+[Illustration: Soft glow on face; hat lowered; chalk heart near a knot untied.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page20.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page20.md
@@ -1,0 +1,11 @@
+# Page 20
+
+
+The child cups a spark and shapes a new riddle in both hands.
+Whisper one clue that makes it welcoming.
+
+// Code Task: child_invents_riddle() → RESULT: "Stub."
+[python]
+def child_invents_riddle():
+    return "Stub."
+[Illustration: Cupped light; tiny glyphs orbit; key charm on a string.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page20.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page20.md
@@ -1,6 +1,5 @@
 # Page 20
 
-
 The child cups a spark and shapes a new riddle in both hands.
 Whisper one clue that makes it welcoming.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page21.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page21.md
@@ -1,0 +1,11 @@
+# Page 21
+
+
+It wobbles like a three-leg stool; the witch taps one shy leg.
+Which tiny rule would steady it?
+
+// Code Task: nudge_rule() → RESULT: "Stub."
+[python]
+def nudge_rule():
+    return "Stub."
+[Illustration: Stool sketch with a circled leg; dotted “rule” label; knot marker.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page21.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page21.md
@@ -1,6 +1,5 @@
 # Page 21
 
-
 It wobbles like a three-leg stool; the witch taps one shy leg.
 Which tiny rule would steady it?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page22.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page22.md
@@ -1,6 +1,5 @@
 # Page 22
 
-
 Call… the village answers; the pattern finds its rhythm.
 Try the next echo—what comes after?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page22.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page22.md
@@ -1,0 +1,11 @@
+# Page 22
+
+
+Call… the village answers; the pattern finds its rhythm.
+Try the next echo—what comes after?
+
+// Code Task: refine_riddle() → RESULT: "Stub."
+[python]
+def refine_riddle():
+    return "Stub."
+[Illustration: Curved sound lines between mouths; chalk beats like notes.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page23.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page23.md
@@ -1,0 +1,11 @@
+# Page 23
+
+
+Laughter rings like small bells; every voice fits the circle.
+Invite someone quiet to add a hint.
+
+// Code Task: laughter_inclusive() → RESULT: "Stub."
+[python]
+def laughter_inclusive():
+    return "Stub."
+[Illustration: Ring of neighbors; open space saved; flower-question marks.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page23.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page23.md
@@ -1,6 +1,5 @@
 # Page 23
 
-
 Laughter rings like small bells; every voice fits the circle.
 Invite someone quiet to add a hint.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page24.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page24.md
@@ -1,0 +1,11 @@
+# Page 24
+
+
+Petals of maybe bloom across the dark like lantern stars.
+Point to one glow you want to follow.
+
+// Code Task: question_flowers() → RESULT: "Stub."
+[python]
+def question_flowers():
+    return "Stub."
+[Illustration: Constellations as blooming questions; gentle purples and golds.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page24.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page24.md
@@ -1,6 +1,5 @@
 # Page 24
 
-
 Petals of maybe bloom across the dark like lantern stars.
 Point to one glow you want to follow.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page25.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page25.md
@@ -1,0 +1,11 @@
+# Page 25
+
+
+Boards bloom with clear, kind rules you can test and try.
+Add one rule that helps new players in.
+
+// Code Task: write_gentle_rules() → RESULT: "Stub."
+[python]
+def write_gentle_rules():
+    return "Stub."
+[Illustration: Three boards: “clear,” “kind,” “testable”; kids chalking.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page25.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page25.md
@@ -1,6 +1,5 @@
 # Page 25
 
-
 Boards bloom with clear, kind rules you can test and try.
 Add one rule that helps new players in.
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page26.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page26.md
@@ -1,6 +1,5 @@
 # Page 26
 
-
 A small knot hums softly, not ready yet, and that’s okay.
 What wonder would you save for later?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page26.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page26.md
@@ -1,0 +1,11 @@
+# Page 26
+
+
+A small knot hums softly, not ready yet, and that’s okay.
+What wonder would you save for later?
+
+// Code Task: unsolved_wonder() → RESULT: "Stub."
+[python]
+def unsolved_wonder():
+    return "Stub."
+[Illustration: Single knot bud glowing; closed keyhole sketch nearby.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page27.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page27.md
@@ -1,6 +1,5 @@
 # Page 27
 
-
 The witch smiles, holding a tiny knot in her palm. “Some doors open slowly.”
 What gentle question would you ask the knot?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page27.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page27.md
@@ -1,0 +1,11 @@
+# Page 27
+
+
+The witch smiles, holding a tiny knot in her palm. “Some doors open slowly.”
+What gentle question would you ask the knot?
+
+// Code Task: witch_smiles() → RESULT: "Stub."
+[python]
+def witch_smiles():
+    return "Stub."
+[Illustration: Witch smiling softly, open palm with a glowing knot; warm twilight, question-flower nearby.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page28.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page28.md
@@ -1,6 +1,5 @@
 # Page 28
 
-
 Lanterns light the path home, each step a soft goodbye and a promise to return.
 Who would you invite to walk beside you?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page28.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page28.md
@@ -1,0 +1,11 @@
+# Page 28
+
+
+Lanterns light the path home, each step a soft goodbye and a promise to return.
+Who would you invite to walk beside you?
+
+// Code Task: farewell_lantern_path() → RESULT: "Stub."
+[python]
+def farewell_lantern_path():
+    return "Stub."
+[Illustration: Lanterns along a winding path, friends walking together, gentle night colors.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page29.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page29.md
@@ -1,6 +1,5 @@
 # Page 29
 
-
 Tuck this game in your pocket: “Repair a riddle with me!”
 What’s the first rule you’d make together?
 

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page29.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page29.md
@@ -1,0 +1,11 @@
+# Page 29
+
+
+Tuck this game in your pocket: “Repair a riddle with me!”
+What’s the first rule you’d make together?
+
+// Code Task: repair_riddle_game() → RESULT: "Stub."
+[python]
+def repair_riddle_game():
+    return "Stub."
+[Illustration: Two hands holding a chalkboard, a riddle half-solved, key and knot doodles.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page30.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page30.md
@@ -1,0 +1,10 @@
+# Page 30
+
+
+Grown-ups: Kind riddles welcome every voice and grow with gentle rules.
+
+// Code Task: authors_note() → RESULT: "Stub."
+[python]
+def authors_note():
+    return "Stub."
+[Illustration: Open circle of adults and children, chalk glyphs and question-flowers around.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page30.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page30.md
@@ -1,6 +1,5 @@
 # Page 30
 
-
 Grown-ups: Kind riddles welcome every voice and grow with gentle rules.
 
 // Code Task: authors_note() → RESULT: "Stub."

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page31.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page31.md
@@ -1,6 +1,5 @@
 # Page 31
 
-
 Curiosity glimmers—another puzzle waits just beyond the next lantern.
 
 // Code Task: back_cover_teaser() → RESULT: "Stub."

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page31.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page31.md
@@ -1,0 +1,10 @@
+# Page 31
+
+
+Curiosity glimmers—another puzzle waits just beyond the next lantern.
+
+// Code Task: back_cover_teaser() → RESULT: "Stub."
+[python]
+def back_cover_teaser():
+    return "Stub."
+[Illustration: Lantern at the edge of the page, a keyhole glowing in the distance, soft golds and purples.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page32.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page32.md
@@ -1,0 +1,10 @@
+# Page 32
+
+
+The story winks: “What gentle wonder will you help unlock next?”
+
+// Code Task: back_cover_teaser() → RESULT: "Stub."
+[python]
+def back_cover_teaser():
+    return "Stub."
+[Illustration: A winking question-flower, a tiny knot and key, hinting at new adventures.]

--- a/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page32.md
+++ b/a0_0_treasury_of_fairytales/a0_1_the_witch_who_broke_riddles/page32.md
@@ -1,6 +1,5 @@
 # Page 32
 
-
 The story winks: “What gentle wonder will you help unlock next?”
 
 // Code Task: back_cover_teaser() → RESULT: "Stub."


### PR DESCRIPTION
* Restore 32 pages from last good state
* Canonical treasury layout enforced
* Lint/stub/build green; two-zip policy intact