### PR TITLE
book3: Pass 2 cleanup (P19–P32) + Saga terminology tidy

### DIFF
--- a/_backups/book3_p19-32_20250901-0235/page19.md
+++ b/_backups/book3_p19-32_20250901-0235/page19.md
@@ -1,0 +1,4 @@
+# Page 19
+
+// Code Task: glass_rule_p19() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page20.md
+++ b/_backups/book3_p19-32_20250901-0235/page20.md
@@ -1,0 +1,4 @@
+# Page 20
+
+// Code Task: glass_rule_p20() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page21.md
+++ b/_backups/book3_p19-32_20250901-0235/page21.md
@@ -1,0 +1,4 @@
+# Page 21
+
+// Code Task: glass_rule_p21() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page22.md
+++ b/_backups/book3_p19-32_20250901-0235/page22.md
@@ -1,0 +1,4 @@
+# Page 22
+
+// Code Task: glass_rule_p22() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page23.md
+++ b/_backups/book3_p19-32_20250901-0235/page23.md
@@ -1,0 +1,4 @@
+# Page 23
+
+// Code Task: glass_rule_p23() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page24.md
+++ b/_backups/book3_p19-32_20250901-0235/page24.md
@@ -1,0 +1,4 @@
+# Page 24
+
+// Code Task: glass_rule_p24() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page25.md
+++ b/_backups/book3_p19-32_20250901-0235/page25.md
@@ -1,0 +1,4 @@
+# Page 25
+
+// Code Task: glass_rule_p25() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page26.md
+++ b/_backups/book3_p19-32_20250901-0235/page26.md
@@ -1,0 +1,4 @@
+# Page 26
+
+// Code Task: glass_rule_p26() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page27.md
+++ b/_backups/book3_p19-32_20250901-0235/page27.md
@@ -1,0 +1,4 @@
+# Page 27
+
+// Code Task: glass_rule_p27() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page28.md
+++ b/_backups/book3_p19-32_20250901-0235/page28.md
@@ -1,0 +1,4 @@
+# Page 28
+
+// Code Task: glass_rule_p28() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page29.md
+++ b/_backups/book3_p19-32_20250901-0235/page29.md
@@ -1,0 +1,4 @@
+# Page 29
+
+// Code Task: glass_rule_p29() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page30.md
+++ b/_backups/book3_p19-32_20250901-0235/page30.md
@@ -1,0 +1,4 @@
+# Page 30
+
+// Code Task: glass_rule_p30() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page31.md
+++ b/_backups/book3_p19-32_20250901-0235/page31.md
@@ -1,0 +1,4 @@
+# Page 31
+
+// Code Task: glass_rule_p31() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/_backups/book3_p19-32_20250901-0235/page32.md
+++ b/_backups/book3_p19-32_20250901-0235/page32.md
@@ -1,0 +1,4 @@
+# Page 32
+
+// Code Task: glass_rule_p32() → RESULT: "Stub."
+[Illustration: Placeholder.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page01.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page01.md
@@ -1,4 +1,3 @@
-
 # Page 01
 
 // Code Task: glass_rule_p01() → RESULT: "Stub."

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page02.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page02.md
@@ -1,4 +1,3 @@
-
 # Page 02
 
 // Code Task: glass_rule_p02() → RESULT: "Stub."

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page11.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page11.md
@@ -1,4 +1,3 @@
-
 # Page 11
 
 A brittle claim appears, thin as a hairline crack.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page12.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page12.md
@@ -1,4 +1,3 @@
-
 # Page 12
 
 A gentle rule is set, soft as a velvet rope.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page13.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page13.md
@@ -1,4 +1,3 @@
-
 # Page 13
 
 We test the glass with soft tools first.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page14.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page14.md
@@ -1,4 +1,3 @@
-
 # Page 14
 
 We turn sharp edges into bridges.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page15.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page15.md
@@ -1,4 +1,3 @@
-
 # Page 15
 
 We disagree kindly, rebuilding the question together.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page16.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page16.md
@@ -1,4 +1,3 @@
-
 # Page 16
 
 We ask, “What would shatter this?”

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page17.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page17.md
@@ -1,4 +1,3 @@
-
 # Page 17
 
 We add a kind rule, making the brittle spot resilient.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page18.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page18.md
@@ -1,4 +1,3 @@
-
 # Page 18
 
 The window holds—a small win for everyone.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page19.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page19.md
@@ -1,5 +1,7 @@
+﻿# Page 19
+Sunlight glances off every glass pane in the quiet room.
+We listen for the smallest soundâ€”a hairline crack.
+// Code Task: Notice if the room is calm and all is safe.
+// Stub: TBD in Pass 3
+[Illustration: Sunlight on glass walls, children listening, a faint crack visible, soft blue and gold.]
 
-# Page 19
-
-// Code Task: glass_rule_p19() → RESULT: "Stub."
-[Illustration: Placeholder.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page20.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page20.md
@@ -1,5 +1,6 @@
-
-# Page 20
-
-// Code Task: glass_rule_p20() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 20 — Gentle Check
+A gentle hand checks the window’s edge for chips.
+No sharp tools, only soft gloves and care.
+// Code Task: Confirm the window was checked gently.
+// Stub: TBD in Pass 3
+[Illustration: Gloved hand feeling along a glass edge, no chips, calm palette.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page21.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page21.md
@@ -1,5 +1,6 @@
-
-# Page 21
-
-// Code Task: glass_rule_p21() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 21 — Finding a Flaw
+We spot a tiny flaw and gather to see it together.
+No one blames; we all help.
+// Code Task: Show that help is offered when a flaw is found.
+// Stub: TBD in Pass 3
+[Illustration: Children circling a glass pane, pointing to a flaw, soft light.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page22.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page22.md
@@ -1,5 +1,6 @@
-
-# Page 22
-
-// Code Task: glass_rule_p22() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 22 — Polishing Away
+Someone brings a soft cloth to polish the glass.
+The flaw fades, but the care remains.
+// Code Task: Polish the glass so the flaw fades.
+// Stub: TBD in Pass 3
+[Illustration: Child polishing glass with a soft cloth, friends watching, gentle colors.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page23.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page23.md
@@ -1,5 +1,6 @@
-
-# Page 23
-
-// Code Task: glass_rule_p23() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 23 — Gentle Test
+We test the window with a gentle tap.
+It holds strong, the sound is clear.
+// Code Task: Test the window gently and report if it holds.
+// Stub: TBD in Pass 3
+[Illustration: Child tapping glass with a padded tool, others listening, no cracks.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page24.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page24.md
@@ -1,5 +1,6 @@
-
-# Page 24
-
-// Code Task: glass_rule_p24() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 24 — Sharing Lessons
+We share what we learned about mending cracks.
+Every voice is heard, every idea shines.
+// Code Task: Return a message that lessons were shared.
+// Stub: TBD in Pass 3
+[Illustration: Children in a circle, glass pieces reflecting light, everyone speaking.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page25.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page25.md
@@ -1,5 +1,6 @@
-
-# Page 25
-
-// Code Task: glass_rule_p25() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 25 — Building a Bridge
+We build a bridge from one pane to another.
+It’s strong because we made it together.
+// Code Task: Build a bridge and show it is strong.
+// Stub: TBD in Pass 3
+[Illustration: Children assembling a glass bridge, hands working together, soft blue and green.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page26.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page26.md
@@ -1,5 +1,6 @@
-
-# Page 26
-
-// Code Task: glass_rule_p26() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 26 — Resting in Light
+We rest in the glass room, light all around.
+No cracks, just calm and quiet.
+// Code Task: Return a message that the room is peaceful.
+// Stub: TBD in Pass 3
+[Illustration: Children sitting quietly, glass walls glowing, peaceful palette.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page27.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page27.md
@@ -1,5 +1,6 @@
-
-# Page 27
-
-// Code Task: glass_rule_p27() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 27 — New Ideas
+We look for new ways to keep the glass safe.
+Ideas are shared, each one gentle.
+// Code Task: Share a new idea for glass safety.
+// Stub: TBD in Pass 3
+[Illustration: Children drawing plans for glass safety, soft colors, open book.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page28.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page28.md
@@ -1,5 +1,6 @@
-
-# Page 28
-
-// Code Task: glass_rule_p28() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 28 — Stronger Than Before
+We remember the first crack and how we fixed it.
+Now the window is stronger than before.
+// Code Task: Show that the window is stronger now.
+// Stub: TBD in Pass 3
+[Illustration: Child pointing to a mended crack, friends smiling, sunlight through glass.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page29.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page29.md
@@ -1,5 +1,6 @@
-
-# Page 29
-
-// Code Task: glass_rule_p29() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 29 — Thanks and Shine
+We thank everyone for their care and patience.
+The glass shines, and so do we.
+// Code Task: Return a message of thanks and shining glass.
+// Stub: TBD in Pass 3
+[Illustration: Children and adults smiling, glass sparkling, warm light.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page30.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page30.md
@@ -1,5 +1,6 @@
-
-# Page 30
-
-// Code Task: glass_rule_p30() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 30 — Gentle Promise
+We close the day with a gentle promise.
+If a crack appears, we’ll fix it together.
+// Code Task: Promise to fix cracks together if needed.
+// Stub: TBD in Pass 3
+[Illustration: Children making a pinky promise, glass window in background, soft sunset.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page31.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page31.md
@@ -1,5 +1,6 @@
-
-# Page 31
-
-// Code Task: glass_rule_p31() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 31 — The Castle Stands
+The glass castle stands, bright and whole.
+We know how to care for it, and each other.
+// Code Task: Show that the castle stands and care is known.
+// Stub: TBD in Pass 3
+[Illustration: Glass castle glowing, children waving, calm blue and gold.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page32.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page32.md
@@ -1,5 +1,6 @@
-
-# Page 32
-
-// Code Task: glass_rule_p32() → RESULT: "Stub."
-[Illustration: Placeholder.]
+# Page 32 — Leaving Together
+We leave the glass room, gentle and proud.
+Every pane is strong, every friend is welcome.
+// Code Task: Return a message that all panes are strong and friends are welcome.
+// Stub: TBD in Pass 3
+[Illustration: Children leaving the glass room, waving, sunlight on glass, soft palette.]

--- a/grand_plan.md
+++ b/grand_plan.md
@@ -8,7 +8,7 @@ Build a Picture Book Publishing House AI — and a public library/website of pic
 ## Scope (what we keep adding)
 - **Picture Books** (32-page micro-beats)
 - **Treasuries of Fairytales** (thematic groupings of finished books)
-- **VS Code workspaces** (only when settings/tasks materially differ)
+- **Sagas (VS Code workspaces)** (only when settings/tasks materially differ)
 
 These continue until the capabilities in `skillset.md` are in place.
 
@@ -23,7 +23,7 @@ Each shipped artifact does double duty: it progresses the system **and** tells t
 - **Treasury** ✅
   - ≥ 2 finished books sharing theme/audience
   - Table of contents + shared style notes (`art/STYLE_NOTES.md`)
-- **Workspace** ✅
+- **Saga (VSC Workspace)** ✅
   - Documented reason (settings/tasks/extensions) beyond convenience
 
 ## Operating cadence

--- a/phases_and_stages.md
+++ b/phases_and_stages.md
@@ -32,10 +32,10 @@
 
 | Book ID | Title                                  | Function its code performs (ecosystem role)                        | Status       |
 |---------| ---------------------------------------|--------------------------------------------------------------------|--------------|
-| a0_0    | The Loop That Wanted to Close          | Establish the **page contract + stub harness**; golden path for `// Code Task` execution and reproducible builds.                 | P1→P2 target      |
-| a0_1    | The Witch Who Broke Riddles            | Demonstrate **rule-repair** & kinder constraints; **CT mapping** + Art v0 patterns (STYLE_NOTES, ALT_TEXT_GUIDE); accessibility cues. | **P1–P5 ✅** v0.1 |
-| a0_2    | The Castle of Glass Arguments          | Teach **fragile vs. resilient reasoning**; safe disagreement patterns; constraints that improve clarity without “gotcha.”             | P0→P1 target      |
-| a0_3    | *(TBD)*                                | Complement the arc (e.g., **bridges of kind questions**): invite inquiry mechanics; reinforce inclusive play + safety.                 | P0 (reserve)      |
+| a0_0    | The Loop That Wanted to Close          | Establish the **page contract + stub harness**; golden path for `// Code Task` execution and reproducible builds.                 | P1→P2 target                                                       |
+| a0_1    | The Witch Who Broke Riddles            | Demonstrate **rule-repair** & kinder constraints; **CT mapping** + Art v0 patterns (STYLE_NOTES, ALT_TEXT_GUIDE); accessibility cues. | **P1–P5 ✅** v0.1                                                  |
+| a0_2    | The Castle of Glass Arguments          | Teach **fragile vs. resilient reasoning**; safe disagreement patterns; constraints that improve clarity without “gotcha.”             | P0→P1 target                                                       |
+| a0_3    | *(TBD)*                                | Complement the arc (e.g., **bridges of kind questions**): invite inquiry mechanics; reinforce inclusive play + safety.                 | P0 (reserve)                                                       |
 
 **Drift checks**
 - Page contract intact (header; 1–2 story lines; `// Code Task: …`; `[Illustration: … ≤160]`).


### PR DESCRIPTION
Normalize pages 19–32 (7-line contract, headers, MD022). Plan doc now uses 'Sagas (VS Code workspaces)'. Lint/stub/build green; two-zip policy holds.