### PR TITLE
docs: sync planning truth + seed-layer triggers

### DIFF
--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page01.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/page01.md
@@ -1,12 +1,11 @@
-o
 # Page 01
 
 The glass room is quiet and bright.
 We begin with gentle hands and open hearts.
 
-// Code Task: glass_rule_p01()  RESULT: "Stub."
+// Code Task: glass_rule_p01() → RESULT: "Stub."
 [python]
 def glass_rule_p01():
-	"""Return True to show the glass rule is set gently."""
-	return True
+    """Return True to show the glass rule is set gently."""
+    return True
 [Illustration: Sunlight on glass walls, children entering quietly, soft blue and gold.]

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/README.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/README.md
@@ -1,6 +1,6 @@
 # Book 3 — Taskmaps (The Castle of Glass Arguments)
 
-**Status:** Pass-3 COMPLETE; Pass-4 IN PROGRESS • **Owner:** Mark R. Gillam • **Last updated:** 2025-09-01
+**Status:** Pass-3 COMPLETE; Pass-4 OPTIONAL/TBD • **Owner:** Mark R. Gillam • **Last updated:** 2025-09-01
 **Purpose:** Planning and audit trail for Book 3 work. Mirrors code reality (pages, tests, zips).
 
 ---
@@ -9,16 +9,13 @@
 
 - Pages (P01–P32) conform to the **7-line page contract**:
   - H1 page title; 1–2 story lines; `// Code Task: …`; `[python]` deterministic stub (4-space indents, no tabs); single `[Illustration: …]` ≤160 chars; UTF-8 + LF; one blank after H1.
-- Build discipline: two-zip rotation; reproducible zips; stub + lint checks green.
+- P01–P32 contract-clean; lint/stub/build green; zips confirmed (two-zip rotation).
 
-## CURRENT FOCUS (Pass-4)
+## NEXT (Pass-4 Optional/TBD)
 
-1. Verify latest two ZIP hashes logged (`fluff_inventory.md`).
-2. Release notes entry + build tag (Book 3 Pass-3→4).
-3. Light polish (illustration phrasing, cadence) without breaking contract.
-4. Regenerate zips post-polish; confirm stable hashes.
-5. Mark Pass-4 COMPLETE.
+- If scheduled: light polish (illustration phrasing, cadence) without breaking contract.
+- If executed: verify latest two ZIP hashes logged (`fluff_inventory.md`), add release notes entry/tag, confirm reproducible hash stability.
 
 ## UPCOMING (Optional)
 
-- Art Pass v0 (style notes + alt-text guide) — schedule after Pass-4 completion.
+- Art Pass v0 (style notes + alt-text guide) — only after any Pass-4 polish.

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/main_taskmap.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/main_taskmap.md
@@ -1,7 +1,7 @@
 # Taskmap — Book 3 (The Castle of Glass Arguments)
 
 **Scope:** Track granular tasks for Book 3.
-**Status:** Pass-3 COMPLETE; Pass-4 (repro zips + polish) IN PROGRESS.
+**Status:** Pass-3 COMPLETE; Pass-4 OPTIONAL/TBD.
 
 ---
 
@@ -9,25 +9,21 @@
 
 - All pages P01–P32 verified via `tests/page_stub_check.py`, `_scripts/lint_pages.ps1`, and `_scripts/make_zips.ps1`.
 - Deterministic 7‑line contract enforced (no tabs, 4-space indents).
-- Initial clean zips exist; full Pass-4 signoff still needs release bookkeeping (notes + hash record).
+- P01–P32 contract-clean; lint/stub/build green; zips confirmed (two-zip rotation).
 
 ## PIPELINE PASSES
 
 - Pass-1 Structure (DONE)
 - Pass-2 Narrative alignment (DONE)
 - Pass-3 Deterministic stubs & schema (DONE)
-- Pass-4 Reproducible zips + light polish (IN PROGRESS)
-  - Core requirements: two-zip rotation refreshed, SHA256 logged, roadmap + release notes updated.
-  - Optional micro‑polish: tighten illustration phrasing; trim any line >160 chars (goal ≤150 where natural); micro cadence edits without breaking contract.
+- Pass-4 Reproducible zips + light polish (OPTIONAL/TBD)
+  - If undertaken: refresh two-zip rotation, log SHA256, update roadmap + release notes.
+  - Micro‑polish scope (optional): tighten illustration phrasing; trim any line >160 chars; cadence edits (maintain contract).
 
-## ACTIVE TASKS
+## OPTIONAL TASKS (Pass-4 Candidate)
 
-- [x] P01–P32 stub check green
-- [x] Lint green
-- [x] Clean zips rotated (initial)
-- [ ] Confirm two most recent ZIP hashes appended to `fluff_inventory.md`
-- [ ] Release notes entry (Book 3 Pass-3→4) with build tag + primary ZIP SHA
-- [ ] Roadmaps snapshot updated with “Pass-4 IN PROGRESS” (main roadmap already shows Pass-3 complete)
-- [ ] Final polish sweep (illustration line length, spacing, trailing blanks)
-- [ ] Regenerate zips post-polish & verify hashes stable
-- [ ] Mark Pass-4 COMPLETE (then consider optional Art v0 later)
+- [ ] If Pass-4 scheduled: confirm two most recent ZIP hashes appended to `fluff_inventory.md`
+- [ ] If Pass-4 scheduled: release notes entry with build tag + primary ZIP SHA
+- [ ] If Pass-4 scheduled: final polish sweep (illustration length, spacing, trailing blanks)
+- [ ] If Pass-4 scheduled: regenerate zips post-polish & verify hashes stable
+- [ ] If Pass-4 executed: mark Pass-4 COMPLETE (then consider optional Art v0 later)

--- a/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/milestones.md
+++ b/a0_0_treasury_of_fairytales/a0_2_the_castle_of_glass_arguments/taskmaps/milestones.md
@@ -2,12 +2,12 @@
 
 - **2025-09-01** — Pass-3 COMPLETE (P01–P32)
   - Deterministic Python stubs; 4-space indents; `[python]` fences; 7-line contract.
-  - Tests + lint + build green; two-zip rotation updated.
+  - P01–P32 contract-clean; lint/stub/build green; two-zip rotation confirmed.
 
-- **NEXT (Pass-4 IN PROGRESS)** — Reproducible zips + light polish
-  - Ensure two most recent ZIP hashes logged to `fluff_inventory.md`.
-  - Update release notes with tag + primary ZIP SHA.
-  - Optional: tighten illustration phrasing; micro cadence edits (no contract drift).
+- **OPTIONAL (Pass-4 TBD)** — Reproducible zips + light polish (only if scheduled)
+  - Would ensure two most recent ZIP hashes logged to `fluff_inventory.md`.
+  - Would add release notes with tag + primary ZIP SHA.
+  - Optional polish: tighten illustration phrasing; micro cadence edits (no contract drift).
 
-- **FUTURE (Optional)** — Art Pass v0 (if scheduled after Pass-4)
+- **FUTURE (Optional)** — Art Pass v0 (if scheduled after any Pass-4)
 

--- a/a0_0_treasury_of_fairytales/roadmaps/README.md
+++ b/a0_0_treasury_of_fairytales/roadmaps/README.md
@@ -22,7 +22,7 @@ They differ from taskmaps, which track progress inside a single picture book.
 - **Roadstanza 0 — Foundations**
   - Book 1 (*The Loop That Wanted to Close*) is complete through **Pass 4 (Validation / Play)** (optional Art pass still open).
   - Book 2 (*The Witch who Broke Riddles*) is complete through **Pass 5 (Art v0.1)**.
-  - Book 3 (*The Castle of Glass Arguments*) is complete through **Pass 3 (stubs P01–P32 contract-complete, lint/stub/build checks green)**; Pass 4 in progress.
+  - Book 3 (*The Castle of Glass Arguments*) is complete through **Pass 3 (P01–P32 contract-clean; lint/stub/build green; zips confirmed)**; Pass 4 optional/TBD.
   - Stable reproducible build process: lint + stub check + zip rotation (latest + one timestamped), SHA256 checksums verified.
   - Optional passes (Art, Export, Gameplay) remain available.
 

--- a/a0_0_treasury_of_fairytales/roadmaps/main_roadmap.md
+++ b/a0_0_treasury_of_fairytales/roadmaps/main_roadmap.md
@@ -23,7 +23,7 @@
 |---|-------------------------------------------------|---------------------------------------|-----------------------|---------------|
 | 1 | `a0_0_the_loop_that_wanted_to_close`            | The Loop that Wanted to Close         | **Pass-4 COMPLETE**   | Optional Art pass open |
 | 2 | `a0_1_the_witch_who_broke_riddles`              | The Witch Who Broke Riddles           | **Pass-5 (Art v0.1)** | P1–P5 baseline complete |
-| 3 | `a0_2_the_castle_of_glass_arguments`            | The Castle of Glass Arguments         | **Pass-3 COMPLETE**   | P01–P32 contract-clean; Pass-4 (repro zips) in progress |
+| 3 | `a0_2_the_castle_of_glass_arguments`            | The Castle of Glass Arguments         | **Pass-3 COMPLETE**   | P01–P32 contract-clean; lint/stub/build green; zips confirmed; Pass-4 optional/TBD |
 | 4 | `a0_3_*`                                        | Book 4                                | TBD                   |               |
 | 5 | `a0_4_*`                                        | Book 5                                | TBD                   |               |
 | 6 | `a0_5_*`                                        | Book 6                                | TBD                   |               |
@@ -39,5 +39,6 @@
 |16 | `a1_5_*`                                        | Book 16                               | TBD                   |               |
 
 **Next series actions**
-1) Roll Book 3 through **Pass-4 (P01–P32)**.
-2) Add release-notes entry + (optional) tag for “Book 3 Pass-4 complete”.
+
+1) Initiate Book 4 scaffold.
+2) (Optional) Schedule Pass-4 polish for Book 3 if needed.

--- a/a0_0_treasury_of_fairytales/roadmaps/milestones.md
+++ b/a0_0_treasury_of_fairytales/roadmaps/milestones.md
@@ -9,19 +9,19 @@
 - **Book 1 — *The Loop That Wanted to Close***
   - Pass 1 Scaffold → done
   - Pass 2 Narrative → done
-  - Pass 3 Code (stubs) → done
+  - Pass 3 Code/Schema (stubs) → done
   - Pass 4 Validation / Play → done
   - Reproducible zips confirmed
 - **Book 2 — *The Witch who Broke Riddles***
   - Pass 1 Scaffold → done
   - Pass 2 Narrative → done
-  - Pass 3 Code (stubs) → done
+  - Pass 3 Code/Schema (stubs) → done
   - Pass 4 Validation / Play → done
 - **Book 3 — *The Castle of Glass Arguments***
   - Pass 1 Scaffold → done
   - Pass 2 Narrative → done
-  - Pass 3 code (stubs P01–P32 contract-complete, lint/stub/build checks green) → done
-  - Pass 4 (reproducible zips) in progress
+  - Pass 3 Code/Schema (P01–P32 contract-clean; lint/stub/build green; zips confirmed) → done
+  - Pass 4 optional/TBD
 
 ### 🚧 Pending
 - **Book 4 — ***

--- a/a0_0_treasury_of_fairytales/roadmaps/roadstanza_0.md
+++ b/a0_0_treasury_of_fairytales/roadmaps/roadstanza_0.md
@@ -22,7 +22,7 @@
 |---------|----------------------------------------|---------------------------------------------|-------------------------------------|
 | a0_0    | The Loop That Wanted to Close          | Establish the **page contract + stub harness**; golden path for `// Code Task` execution and reproducible builds.                 | P1–P4 ✅                                    |
 | a0_1    | The Witch Who Broke Riddles            | Demonstrate **rule-repair** & kinder constraints; **CT mapping**; Art v0 patterns (STYLE_NOTES, ALT_TEXT_GUIDE); accessibility cues. | P1–P5 ✅ (v0.1)                             |
-| a0_2    | The Castle of Glass Arguments          | Teach **fragile vs. resilient reasoning**; safe disagreement patterns; constraints that improve clarity without “gotcha”.             | P3 ✅ (stubs P01–P32 contract-complete, lint/stub/build checks green); P4 in progress |
+| a0_2    | The Castle of Glass Arguments          | Teach **fragile vs. resilient reasoning**; safe disagreement patterns; constraints that improve clarity without “gotcha”.             | P3 ✅ (P01–P32 contract-clean; lint/stub/build green; zips confirmed; P4 optional/TBD) |
 | a0_3    | *(TBD)*                                | Complement the arc (e.g., **bridges of kind questions**): inquiry mechanics; inclusive play + safety.                           | P0 (reserve)                                |
 
 ### Drift checks (keep these true)

--- a/docs/fluff_inventory.md
+++ b/docs/fluff_inventory.md
@@ -1,61 +1,9 @@
 # Fluff Inventory
 
-> Generated: 2025-08-31 22:03:08 +10:00
+> Single snapshot (manual sync). Update only on release-worthy build events.
 
-## Summary
-
-| Item | Count |
-|---|---:|
-| Root ghost book folders | 0 |
-| Empty (or .gitkeep-only) directories | 5 |
-| Zero-byte files | 19 |
-
-## Root ghost book folders
-
-_None_
-
-## Empty (or .gitkeep-only) directories
-
-| Path |
-|---|
-| .pytest_cache\v |
-| _templates\picture_book_template\assets |
-| a0_0_treasury_of_fairytales\a0_0_the_loop_that_wanted_to_close\assets |
-| a0_0_treasury_of_fairytales\a0_1_the_witch_who_broke_riddles\assets |
-| a0_0_treasury_of_fairytales\a0_2_the_castle_of_glass_arguments\assets |
-
-## Zero-byte files
-
-| Path |
-|---|
-| __init__.py |
-| _templates\__init__.py |
-| _templates\picture_book_template\taskmaps\__init__.py |
-| a0_0_treasury_of_fairytales\__init__.py |
-| a0_0_treasury_of_fairytales\a0_0_the_loop_that_wanted_to_close\__init__.py |
-| a0_0_treasury_of_fairytales\a0_0_the_loop_that_wanted_to_close\README.md |
-| a0_0_treasury_of_fairytales\a0_0_the_loop_that_wanted_to_close\taskmaps\__init__.py |
-| a0_0_treasury_of_fairytales\a0_1_the_witch_who_broke_riddles\__init__.py |
-| a0_0_treasury_of_fairytales\a0_1_the_witch_who_broke_riddles\taskmaps\__init__.py |
-| a0_0_treasury_of_fairytales\a0_2_the_castle_of_glass_arguments\__init__.py |
-| a0_0_treasury_of_fairytales\a0_2_the_castle_of_glass_arguments\taskmaps\__init__.py |
-| a0_0_treasury_of_fairytales\a0_2_the_castle_of_glass_arguments\taskmaps\README.md |
-| a0_0_treasury_of_fairytales\roadmaps\__init__.py |
-| mirror_decisions\__init__.py |
-| mirror_decisions\main_mirror.md |
-| mirror_decisions\milestones.md |
-| mirror_decisions\README.md |
-| template.md |
-| tests\__init__.py |
-
-### Build Snapshot
+## Build Snapshot
 
 - **Latest ZIP:** dist/picture_books_ai_1_clean_latest.zip
-- **Last Hash:** 6D227B80118368A346B4DFFAA8E9C171C19167803834791D906F7C782E40A637
-- **Last Updated:** 2025-09-01 00:28 local
-
-### Build Snapshot
-
-- **Latest ZIP:** dist/picture_books_ai_1_clean_latest.zip
-- **Last Hash:** FA1F0E7B95907521C5C831773AF6E19F906474C8D8CCFD45536011795802F95B
-- **Last Updated:** 2025-09-01 01:44:01 local
+- **Last Hash:** EAE65C80AA772B44807A9D85C2BAD93419271E94799C2F246E77BCABF5C06B57
+- **Last Updated:** 2025-09-01 16:00:20 local


### PR DESCRIPTION
Aligns Book 3 status to Pass-3 COMPLETE across planning docs; sets Pass-4 optional/TBD.\nAdds Revisit Triggers to layers_of_logic_and_narrative.md to prevent premature over-detail.\nClarifies Pass 3 = Code/Schema in acronyms/build_passes; removes legacy references.\nTracks clean ZIP hash in docs/fluff_inventory.md.\nLint/stub/build already green; two-zip rotation verified.